### PR TITLE
Checkout after edit

### DIFF
--- a/dotfiles
+++ b/dotfiles
@@ -137,15 +137,16 @@ edit-info() {
         printf '%s\n' "$@" >> "$infofile"
     fi
     git --git-dir="$dotfiles_dir" update-index --add --cacheinfo 10064,$(git --git-dir="$dotfiles_dir" hash-object -w "$infofile"),"$dotfile"
+    git --git-dir "$dotfiles_dir" checkout --quiet
 }
-
 
 readme() {
     readme_file="$(mktemp --suffix .md)"
+    trap 'rm -f "$readme_file"' SIGINT SIGTERM EXIT
     git --git-dir="$dotfiles_dir" show :README.md > "$readme_file"
     ${EDITOR:-vim} "$readme_file"
     git --git-dir="$dotfiles_dir" update-index --add --cacheinfo 10064,$(git --git-dir="$dotfiles_dir" hash-object -w "$readme_file"),README.md
-    rm "$readme_file"
+    git --git-dir "$dotfiles_dir" checkout --quiet
 }
 
 # Main


### PR DESCRIPTION
Run `git checkout` after editing hidden (through sparse checkout) files to refresh the state of these files.

Git marks these files as deleted after editing or opening the files. Running `git checkout` without additional parameters is non-destructive, sparsely checks out missing files and marks the files correctly (either as modified or not).

Also swapped `rm` with `trap` to ensure the deletion.