### PR TITLE
Checkout after edit

### DIFF
--- a/dotfiles
+++ b/dotfiles
@@ -141,8 +141,8 @@ edit_info() {
         printf '%s\n' "$@" >> "$infofile"
     fi
     git --git-dir="$dotfiles_dir" update-index --add --cacheinfo 10064,$(git --git-dir="$dotfiles_dir" hash-object -w "$infofile"),"$dotfile"
+    git --git-dir "$dotfiles_dir" checkout --quiet
 }
-
 
 readme() {
     local readme_file="$(mktemp --suffix .md)"
@@ -150,6 +150,7 @@ readme() {
     ${EDITOR:-vim} "$readme_file"
     git --git-dir="$dotfiles_dir" update-index --add --cacheinfo 10064,$(git --git-dir="$dotfiles_dir" hash-object -w "$readme_file"),README.md
     rm "$readme_file"
+    git --git-dir "$dotfiles_dir" checkout --quiet
 }
 
 # Main


### PR DESCRIPTION
Run `git checkout` after editing hidden (through sparse checkout) files to refresh the state of these files.

Git marks these files as deleted after editing or opening the files. Running `git checkout` without additional parameters is non-destructive, sparsely checks out missing files and marks the files correctly (either as modified or not).

(Splitting up #1)