### PR TITLE
Ensure .config directory exists

### DIFF
--- a/dotfiles
+++ b/dotfiles
@@ -102,6 +102,7 @@ _EOF_
 
 # Init {{{
 init_setup() {
+    mkdir -p ~/.config
     echo "dotfiles_dir=$dotfiles_dir" > ~/.config/dotfiles.conf
     sparse_tree > "$dotfiles_dir"/info/sparse-checkout
     git --git-dir "$dotfiles_dir" config --local core.bare false


### PR DESCRIPTION
Considering a new user account without any configuration done yet, it's possible that the `~/.config/` directory does not exist. In that case, creating the `dotfiles.conf` file will fail and the command `dotfiles` cannot be used to refer to the repository.